### PR TITLE
Handle parens around object

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ reserved.forEach(function(k) {
 // Out: x["class"] = 3;
 function visitMemberExpression(traverse, node, path, state) {
     traverse(node.object, path, state);
-    utils.catchup(node.object.range[1], state);
+    utils.catchup(node.property.range[0] - 1, state);
     utils.append('[', state);
     utils.catchupWhiteSpace(node.property.range[0], state);
     utils.append('"', state);

--- a/spec/es3ifyspec.js
+++ b/spec/es3ifyspec.js
@@ -9,6 +9,8 @@ describe('es3ify', function() {
     it('should quote member properties', function() {
         expect(transform('x.dynamic++; x.static++;'))
                 .toEqual('x.dynamic++; x["static"]++;');
+        expect(transform('({}).static;'))
+            .toEqual('({})["static"];');
     });
 
     it('should remove trailing commas in arrays', function() {
@@ -28,6 +30,6 @@ describe('es3ify', function() {
 
     it('should transform everything at once', function() {
         expect(transform('({a:2,\tfor :[2,,3,],}\n.class)'))
-                .toEqual('({a:2,\t"for" :[2,,3]}[\n"class"])');
+                .toEqual('({a:2,\t"for" :[2,,3]}\n["class"])');
     });
 });


### PR DESCRIPTION
It's more reliable to start from from `property.range[0] - 1`
