### PR TITLE
use try catch to forward errors to browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,16 @@ function process(file) {
     }
 
     function compile() {
-        this.queue(transform(data));
+
+        var source;
+
+        try {
+          source = transform(data);
+        } catch (e) {
+          return this.emit('error', e);
+        }
+
+        this.queue(source);
         this.queue(null);
     }
 

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ function transform(code) {
 }
 
 function process(file) {
+    if (/\.json$/.test(file)) return through();
     var data = '';
     function write(chunk) {
         data += chunk;


### PR DESCRIPTION
Use try/catch to catch errors from the jstransform module and emit them back to the browserify pipeline instead.

I also added a check to make es3ify ignore JSON files