### PR TITLE
transform js files only, preventing conflicts with other input source files

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function transform(code) {
 }
 
 function process(file) {
-    if (/\.json$/.test(file)) return through();
+    if (!/\.js$/.test(file)) return through();
     var data = '';
     function write(chunk) {
         data += chunk;


### PR DESCRIPTION
Currently es3ify check the file name to filter JSON file (as it can't and should not transform them).
I assume this was done to fix browserify crashes with this transform. But it dit not resolve the issue for other input files. 
es3ify should try to transform javascript file only, so a more permanent fix seems to ignore anything else