### PR TITLE
Update esprima

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Syntax = require('esprima-fb').Syntax;
+var Syntax = require('esprima').Syntax;
 var jstransform = require('jstransform');
 var through = require('through');
 var utils = require('jstransform/src/utils');

--- a/package.json
+++ b/package.json
@@ -1,28 +1,28 @@
 {
-    "name": "es3ify",
-    "version": "0.1.4",
-    "description": "Browserify transform to convert ES5 syntax to be ES3-compatible.",
-    "main": "index.js",
-    "dependencies": {
-        "esprima-fb": "~3001.0001.0000-dev-harmony-fb",
-        "jstransform": "~3.0.0",
-        "through": "~2.3.4"
-    },
-    "devDependencies": {
-        "jasmine-node": "~1.13.1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/spicyj/es3ify.git"
-    },
-    "scripts": {
-        "test": "jasmine-node spec"
-    },
-    "homepage": "https://github.com/spicyj/es3ify",
-    "author": {
-        "name": "Ben Alpert",
-        "email": "ben@benalpert.com",
-        "url": "http://benalpert.com"
-    },
-    "license": "MIT"
+  "name": "es3ify",
+  "version": "0.1.4",
+  "description": "Browserify transform to convert ES5 syntax to be ES3-compatible.",
+  "main": "index.js",
+  "dependencies": {
+    "esprima": "^2.7.1",
+    "jstransform": "~3.0.0",
+    "through": "~2.3.4"
+  },
+  "devDependencies": {
+    "jasmine-node": "~1.13.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/spicyj/es3ify.git"
+  },
+  "scripts": {
+    "test": "jasmine-node spec"
+  },
+  "homepage": "https://github.com/spicyj/es3ify",
+  "author": {
+    "name": "Ben Alpert",
+    "email": "ben@benalpert.com",
+    "url": "http://benalpert.com"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#7. This accomplishes two things:

- we're now using upstream [esprima](https://www.npmjs.com/package/esprima) instead of esprima-fb, which is now deprecated

- this makes it compatible with non-npm package managers like [ied](https://github.com/alexanderGugel/ied), because `"esprima-fb": "~3001.0001.0000-dev-harmony-fb"` is actually invalid semver