### PR TITLE
Test in node 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
 - "0.10"
+- "4"


### PR DESCRIPTION
es3ify is running tests on ancient 0.10. This adds node 4.x testing as well.