### PR TITLE
upgrade jstransform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
 - "0.10"
 - "4"
+- "6"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "esprima": "^2.7.1",
-    "jstransform": "~3.0.0",
+    "jstransform": "~11.0.0",
     "through": "~2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
the current version has invalid semvar that newer versions of npm explode on preventing modules that rely on es3ify from being installed