### PR TITLE
Fixes: Transforming a comma only array to an empty array fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,11 +75,6 @@ function visitArrayOrObjectExpression(traverse, node, path, state) {
         node.elements :
         node.properties;
     elements.forEach(function(element, i) {
-        if (element == null && i === elements.length - 1) {
-            throw new Error(
-                "Elisions ending an array are interpreted inconsistently " +
-                "in IE8; remove the extra comma or use 'undefined' explicitly");
-        }
         if (element != null) {
             // Copy commas from after previous element, if any
             utils.catchup(element.range[0], state);

--- a/spec/es3ifyspec.js
+++ b/spec/es3ifyspec.js
@@ -15,6 +15,11 @@ describe('es3ify', function() {
         expect(transform('[2, 3, 4,]'))
                 .toEqual('[2, 3, 4]');
     });
+    
+    it('should remove all commas in comma only arrays', function() {
+        expect(transform('[,,,]'))
+                .toEqual('[]');
+    });
 
     it('should not remove commas in strings in arrays', function() {
         expect(transform('["2, 3, 4,"]'))


### PR DESCRIPTION
When the code contains [,,,] this library throws an exception instead of transforming it to [].

This PR fixes that.

I added a new test case to the spec as well.

Thanks