### PR TITLE
Fixes: Transforming a comma only array to an empty array fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-node_modules
+node_modules/
+.idea/
+jasmine-node

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var reserved = [
     "double", "enum", "export", "extends", "final", "float", "goto",
     "implements", "import", "int", "interface", "long", "native", "package",
     "private", "protected", "public", "short", "static", "super",
-    "synchronized", "throws", "transient", "volatile",
+    "synchronized", "throws", "transient", "volatile"
 ];
 var reservedDict = {};
 reserved.forEach(function (k) {
@@ -84,7 +84,7 @@ function visitArrayOrObjectExpression(traverse, node, path, state) {
                 utils.append(',', state);
             }
             utils.append('void 0', state);
-            utils.move(previousRange[1], state);
+            utils.catchupWhiteSpace(previousRange[1], state);
         } else {
             previousRange = element.range;
             // Copy commas from after previous element, if any

--- a/index.js
+++ b/index.js
@@ -75,11 +75,6 @@ function visitArrayOrObjectExpression(traverse, node, path, state) {
         node.elements :
         node.properties;
     elements.forEach(function(element, i) {
-        if (element == null && i === elements.length - 1) {
-            throw new Error(
-                "Elisions ending an array are interpreted inconsistently " +
-                "in IE8; remove the extra comma or use 'undefined' explicitly");
-        }
         if (element != null) {
             // Copy commas from after previous element, if any
             utils.catchup(element.range[0], state);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es3ify",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Browserify transform to convert ES5 syntax to be ES3-compatible.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es3ify",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Browserify transform to convert ES5 syntax to be ES3-compatible.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "ssh://git@stash.iaccap.com:7999/wcpm/es3ify.git"
   },
+  "publishConfig": {
+    "registry": "http://nexus.iaccap.com/content/repositories/npm-internal/"
+  },
   "scripts": {
     "test": "jasmine-node spec",
     "build": "npm run test"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/spicyj/es3ify.git"
+    "url": "ssh://git@stash.iaccap.com:7999/wcpm/es3ify.git"
   },
   "scripts": {
     "test": "jasmine-node spec",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "git://github.com/spicyj/es3ify.git"
   },
   "scripts": {
-    "test": "jasmine-node spec"
+    "test": "jasmine-node spec",
+    "build": "npm run test"
   },
   "homepage": "https://github.com/spicyj/es3ify",
   "author": {

--- a/spec/es3ifyspec.js
+++ b/spec/es3ifyspec.js
@@ -15,10 +15,40 @@ describe('es3ify', function() {
         expect(transform('[2, 3, 4,]'))
                 .toEqual('[2, 3, 4]');
     });
-    
-    it('should remove all commas in comma only arrays', function() {
+
+    it('should explicitly add undefined in comma only arrays', function() {
         expect(transform('[,,,]'))
-                .toEqual('[]');
+                .toEqual('[void 0,void 0,void 0]');
+    });
+
+    it('should explicitly add undefined in comma only arrays', function() {
+        expect(transform('[,,2]'))
+            .toEqual('[void 0,void 0,2]');
+    });
+
+    it('should explicitly add undefined in comma only arrays', function() {
+        expect(transform('[3,,2]'))
+            .toEqual('[3,void 0,2]');
+    });
+
+    it('should explicitly add undefined in comma only arrays', function() {
+        expect(transform('[3,,,2]'))
+            .toEqual('[3,void 0,void 0,2]');
+    });
+
+    it('should explicitly add undefined in comma only arrays', function() {
+        expect(transform('[3,,5,,2]'))
+            .toEqual('[3,void 0,5,void 0,2]');
+    });
+
+    it('should explicitly add undefined and remove trailing comma', function() {
+        expect(transform('[2,,]'))
+                .toEqual('[2,void 0]');
+    });
+
+    it('should explicitly add undefined and remove trailing comma', function() {
+        expect(transform('[2,,,]'))
+            .toEqual('[2,void 0,void 0]');
     });
 
     it('should not remove commas in strings in arrays', function() {
@@ -38,6 +68,6 @@ describe('es3ify', function() {
 
     it('should transform everything at once', function() {
         expect(transform('({a:2,\tfor :[2,,3,],}\n.class)'))
-                .toEqual('({a:2,\t"for" :[2,,3]}[\n"class"])');
+                .toEqual('({a:2,\t"for" :[2,void 0,3]}[\n"class"])');
     });
 });

--- a/spec/es3ifyspec.js
+++ b/spec/es3ifyspec.js
@@ -15,6 +15,11 @@ describe('es3ify', function() {
         expect(transform('[2, 3, 4,]'))
                 .toEqual('[2, 3, 4]');
     });
+    
+    it('should remove all commas in comma only arrays', function() {
+        expect(transform('[,,,]'))
+                .toEqual('[]');
+    });
 
     it('should not remove commas in strings in arrays', function() {
         expect(transform('["2, 3, 4,"]'))


### PR DESCRIPTION
Ok, I realized my mistake on the previous PR (#12), this new code will match modern browser behavior in IE8 by replacing empty array elements with explicit undefined. Using void 0 instead of undefined to guarantee the value doesn't change (Undefined can be reassigned). Handles the case of multiple trailing commas correctly (replace all with undefined except for the last one which is discarded.)

thanks