### PR TITLE
True and False are also reserved

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var reserved = [
     "double", "enum", "export", "extends", "final", "float", "goto",
     "implements", "import", "int", "interface", "long", "native", "package",
     "private", "protected", "public", "short", "static", "super",
-    "synchronized", "throws", "transient", "volatile",
+    "synchronized", "throws", "transient", "volatile", "true", "false"
 ];
 var reservedDict = {};
 reserved.forEach(function(k) {


### PR DESCRIPTION
In our project uglify changed an object to {true: xxx} and it was not string escaped which caused parsing failure with Android 2.3.X devices.